### PR TITLE
bug fix: Dockerfile outdated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM build as app-only
 
 EXPOSE 3000
 
-ENTRYPOINT npm start
+ENTRYPOINT npm run start:api:prod
 
 FROM build as standalone
 
@@ -29,4 +29,4 @@ ENV REDIS_URL=redis://localhost:6379
 VOLUME [ "/var/lib/redis" ]
 
 # Start the application
-ENTRYPOINT service redis-server start && npm start
+ENTRYPOINT service redis-server start && npm run start:api:prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:20 as build
+FROM node:20 AS build
 
 # TODO: The deployment docker image should install the reconnection
 #       service from NPM rather than building from source
@@ -10,13 +10,13 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-FROM build as app-only
+FROM build AS app-only
 
 EXPOSE 3000
 
 ENTRYPOINT npm run start:api:prod
 
-FROM build as standalone
+FROM build AS standalone
 
 # Install Redis on top of the base image
 RUN apt-get -y update

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
     "start:api": "nest start",
     "start:api:watch": "nest start --watch",
-    "start:api:prod": "node dist/main.js",
+    "start:api:prod": "node dist/src/main.js",
     "start:api:dev": "set -a ; . .env ; nest start",
     "start:api:debug": "set -a ; . .env ; nest start --debug --watch",
     "docker-build": "docker build -t reconnection-service .",


### PR DESCRIPTION
## Details

It was noted in production that docker image fails with script error due to Dockerfile being outdated

## Fix
-  change entry point in dockerfile to correct script

## Tests
- Ran the prod script locally and was able to start reconnection server